### PR TITLE
g:rocannon_open_action = vsplit

### DIFF
--- a/autoload/rocannon.vim
+++ b/autoload/rocannon.vim
@@ -81,6 +81,10 @@ fun! rocannon#OpenAlternate(action, category)
   "          and fall back to main.yaml
   "        - open dir (browser) for files and templates
   " NOTE: connecting vars with / to avoid "not a file" message
+  if index(['split', 'vsplit', 'edit', 'tabnet'], a:action) == -1
+      echom "Can't open " . a:category . " with g:rocannon_open_action=" . a:action
+      return
+  endif
   let fname = expand('%:p:t')
   let role = expand('%:p:h:h:t') . '/'
   "echom 'will look for: roles/' . role . a:category . '/' . fname

--- a/autoload/rocannon.vim
+++ b/autoload/rocannon.vim
@@ -76,7 +76,7 @@ endfun
 " with :RVars
 
 fun! rocannon#OpenAlternate(action, category)
-  " Action should be one of: split, edit, tabnew
+  " Action should be one of: split, vsplit, edit, tabnew
   " TODO:  - should have some smarts about whether matching files names exists,
   "          and fall back to main.yaml
   "        - open dir (browser) for files and templates

--- a/doc/rocannon.txt
+++ b/doc/rocannon.txt
@@ -218,7 +218,7 @@ Related maps are available if you enable them with:
 The commands all open new window splits by default. If you would instead like
 them to just open the file in the active buffer, or a in new tab, use: >
 
-    :let g:rocannon_open_action = 'split'  " alternatives: tabnew, edit
+    :let g:rocannon_open_action = 'split'  " alternatives: vsplit, tabnew, edit
 
 Note that the standard bouncing actions will also work. With your cursor on
 the `o` you can do |gf| (go to file) or |CTRL-W_F| (go to in split).

--- a/ftplugin/ansible.vim
+++ b/ftplugin/ansible.vim
@@ -50,8 +50,8 @@ endif
 """ Bouncing around (navigation)
 if !exists('g:rocannon_open_action')
   let g:rocannon_open_action = 'split'
-  let act = g:rocannon_open_action  " shorter for convenience herein
 endif
+let act = g:rocannon_open_action  " shorter for convenience herein
 
 "command! AnsVars split %:p:h/../vars/main.yml
 command! AnsVars split group_vars/all.yaml

--- a/ftplugin/ansible.vim
+++ b/ftplugin/ansible.vim
@@ -51,23 +51,23 @@ endif
 if !exists('g:rocannon_open_action')
   let g:rocannon_open_action = 'split'
 endif
-let act = g:rocannon_open_action  " shorter for convenience herein
+let open_action = g:rocannon_open_action  " shorter for convenience herein
 
 "command! AnsVars split %:p:h/../vars/main.yml
 command! AnsVars split group_vars/all.yaml
 
 " Inside role
-command! RHandler  call rocannon#OpenAlternate(act, 'handlers')
-command! RVars     call rocannon#OpenAlternate(act, 'vars')
-command! RPlates   call rocannon#OpenAlternate(act, 'templates')
-command! RTasks    call rocannon#OpenAlternate(act, 'tasks')
-command! RFiles    call rocannon#OpenAlternate(act, 'files')
-command! RDefaults call rocannon#OpenAlternate(act, 'defaults')
-command! RMeta     call rocannon#OpenAlternate(act, 'meta')
+command! RHandler  call rocannon#OpenAlternate(open_action, 'handlers')
+command! RVars     call rocannon#OpenAlternate(open_action, 'vars')
+command! RPlates   call rocannon#OpenAlternate(open_action, 'templates')
+command! RTasks    call rocannon#OpenAlternate(open_action, 'tasks')
+command! RFiles    call rocannon#OpenAlternate(open_action, 'files')
+command! RDefaults call rocannon#OpenAlternate(open_action, 'defaults')
+command! RMeta     call rocannon#OpenAlternate(open_action, 'meta')
 
 " Any complexity means main is just a bunch of includes.
 " RM would be nice for "M"ain but "M"eta might be more important
-command! RIncludes exe act . expand('%:p:h') . '/main.yaml'
+command! RIncludes exe open_action . expand('%:p:h') . '/main.yaml'
 
 " Top level
 command! Rglobals    split group_vars/all.yaml


### PR DESCRIPTION
### Why?

I've been using Rocannon recently (I think it's pretty cool BTW) and I prefer when opening new windows (e.g., with `:RT`) that they open in `vsplit`s. Given monitor aspect ratios these days and line length restrictions in most style guidelines, I think it just makes sense to have the option available.

Anyway, I found `g:rocannon_open_action` listed in the docs and tried changing it to `vsplit`. It didn't work straight away so I dug in to the code a bit and this is what I changed while I was getting it working.
### What?

So there's a few things in here:
- Updated comments and docs to mention that vsplits are an option too.
- Added some basic validation on the `action` argument to `rocannon#OpenAlternate()`.
- Refactored `act` to `open_action` to make things a bit clearer (I don't mind taking this out, I just thought it was more explicit this way).
- Fixed a bug: If you `set g:rocannon_open_action = ...` in your `~/.vimrc` then `act` (renamed to `open_action`) never gets assigned in `ftplugin/ansible.vim`.
### Obligatory GIF

![](http://i.imgur.com/qh5nJvT.gif)
